### PR TITLE
remove preloading of pages as it interferes with custom code

### DIFF
--- a/src/Extensions/ListingsControllerExtension.php
+++ b/src/Extensions/ListingsControllerExtension.php
@@ -15,11 +15,6 @@ class ListingsControllerExtension extends Extension
     private static $listed_pages_classes = [];
     private static $listed_pages_index_only = false;
 
-    public function onBeforeInit()
-    {
-        $this->owner->getListedPages();
-    }
-
     public function getListedPages()
     {
         if ($this->owner->hasDynamicData('listedPages')) {


### PR DESCRIPTION
This preloading interferes with custom code in init() or action methods and results in pages being loaded twice if something custom should be done. Better just leave it and load them when they are needed.